### PR TITLE
Fix default props in NavLink

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -86,7 +86,7 @@ export interface NavLinkProps extends LinkProps {
 }
 
 export function NavLink(props: NavLinkProps) {
-  assignProps(props, { activeClass: 'is-active' });
+  props = assignProps({}, { activeClass: 'is-active' }, props);
   const [, rest] = splitProps(props, ['activeClass', 'end', 'ref']);
   const router = useRouter();
   const route = useRoute();


### PR DESCRIPTION
closes #14. I switched the assignProps call to it's recommended form in [solid docs](https://github.com/ryansolid/solid/blob/master/documentation/components.md#props)